### PR TITLE
Fix multi click event

### DIFF
--- a/3dminecraft13.html
+++ b/3dminecraft13.html
@@ -151,6 +151,7 @@
 
 
 			scene.add(instancedChunk);
+		}
 
 		var keys = [];
 		var canJump = true;
@@ -856,7 +857,6 @@
 		}
 
 			GameLoop();
-		}
 	</script>
 </body>
 </html>


### PR DESCRIPTION
The `for` loop you define at 131 is closed at the very end of the script (859), so it encompasses the majority of the code. The click event is defined at 280:
```js
document.body.addEventListener("click", function(){
```
`addEventListener("click")` doesn't replace the existing click events on the element, it adds the new listener and keeps the other ones. The `for` loop loops over a variable named `renderDistance` (defined at 112) which is currently 5. So every time you did a click, the script executes the listener 5 times, thus placing/removing 5 blocks.
For the movement, it was also in the loop, so that fixed it too.

You can accept this PR to integrate the fix to your code.